### PR TITLE
Add Azure Boards badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kb
+[![Board Status](https://codedev.ms/alexn/afd141fb-6d78-4bbe-887e-94dc12d615eb/3ee2eb27-5418-4aa1-81e9-69f0d668e1c7/_apis/work/boardbadge/e5160510-bfa5-4e46-9d04-de01adda2150)](https://codedev.ms/alexn/afd141fb-6d78-4bbe-887e-94dc12d615eb/_boards/board/t/3ee2eb27-5418-4aa1-81e9-69f0d668e1c7/Microsoft.RequirementCategory)<br/># kb
 kb
 aa
 bbb


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/alexn/afd141fb-6d78-4bbe-887e-94dc12d615eb/_workitems/edit/1)